### PR TITLE
Use npm ci in bootstrap script

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -46,7 +46,11 @@ cleanup() {
 }
 trap cleanup EXIT
 
-echo "==> Frontend: npm install & dev (http://127.0.0.1:5173)"
+echo "==> Frontend: npm ci & dev (http://127.0.0.1:5173)"
 cd "$FRONT"
-npm install
+if [ -d node_modules ]; then
+  echo "node_modules already exists, skipping npm ci"
+else
+  npm ci
+fi
 npm run dev


### PR DESCRIPTION
## Summary
- install frontend dependencies with `npm ci` to respect `package-lock.json`
- skip dependency installation when `node_modules` already exists

## Testing
- `bash -n bootstrap.sh`
- `shellcheck bootstrap.sh`
- `npm test` (fails: Missing script 'test')
- `composer validate`
- `cd frontend && if [ -d node_modules ]; then echo "node_modules already exists, skipping npm ci"; else npm ci --dry-run; fi`


------
https://chatgpt.com/codex/tasks/task_e_6895e31ca138832e84d91ca01f1de042