### PR TITLE
Fix tenancy morph map registration to prevent bootstrap failure

### DIFF
--- a/backend/app/Providers/TenancyServiceProvider.php
+++ b/backend/app/Providers/TenancyServiceProvider.php
@@ -3,8 +3,8 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
-use Spatie\Multitenancy\Models\Tenant;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 class TenancyServiceProvider extends ServiceProvider
 {
@@ -42,7 +42,13 @@ class TenancyServiceProvider extends ServiceProvider
             'engine' => null,
         ]);
 
-        Tenant::morphMap([
+        // Register the morph map using the Relation helper instead of
+        // calling the model directly. Calling the model's `morphMap` method
+        // would attempt to resolve a database connection during the service
+        // provider registration phase, which fails because the connection
+        // resolver has not been set up yet. Using `Relation::enforceMorphMap`
+        // avoids touching the database and fixes bootstrapping.
+        Relation::enforceMorphMap([
             'tenant' => \Spatie\Multitenancy\Models\Tenant::class,
         ]);
     }

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+// Placeholder web routes file required by Laravel's router. The application
+// currently exposes only API endpoints, but the framework expects this file
+// to exist during bootstrap.
+


### PR DESCRIPTION
## Summary
- avoid resolving DB connection during service provider registration by using `Relation::enforceMorphMap`
- add placeholder `routes/web.php` so Laravel's router boots cleanly

## Testing
- `composer install --no-interaction --prefer-dist`
- `php artisan key:generate --force`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6896f6953ab4832eb2b55aaae0efd15f