### PR TITLE
fix: autoload database seeders

### DIFF
--- a/backend/composer.json
+++ b/backend/composer.json
@@ -21,7 +21,9 @@
   "autoload": {
     "psr-4": {
       "App\\": "app/",
-      "Modules\\": "modules/"
+      "Modules\\": "modules/",
+      "Database\\Factories\\": "database/factories/",
+      "Database\\Seeders\\": "database/seeders/"
     }
   },
   "autoload-dev": {


### PR DESCRIPTION
## Summary
- autoload Database seeders and factories

## Testing
- `composer dump-autoload`
- `composer install`
- `php artisan db:seed --class=Database\\Seeders\\LandlordDatabaseSeeder --force` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6896fb01825c832e8a660e561a8b4bae