### PR TITLE
Remove unsupported --force flag from tenant commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Backend `.env` (auto-copied from `.env.example` by `bootstrap.sh`):
 cd backend
 php artisan migrate --database=landlord --path=database/migrations_landlord --force
 php artisan db:seed --class="Database\Seeders\LandlordDatabaseSeeder" --force
-php artisan tenants:migrate:poc --force
-php artisan tenants:seed:poc --force
+php artisan tenants:migrate:poc
+php artisan tenants:seed:poc
 ```
 
 ---

--- a/backend/Envoy.blade.php
+++ b/backend/Envoy.blade.php
@@ -43,12 +43,12 @@ $backend = $release_dir . '/backend';
 
 @task('tenants_migrate', ['on' => 'web'])
     cd {{ $backend }}
-    php artisan tenants:migrate:poc --force
+    php artisan tenants:migrate:poc
 @endtask
 
 @task('tenants_seed', ['on' => 'web'])
     cd {{ $backend }}
-    php artisan tenants:seed:poc --force
+    php artisan tenants:seed:poc
 @endtask
 
 @task('cache_optimize', ['on' => 'web'])

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -63,10 +63,10 @@ echo "==> Landlord seed (creates tenants + their DBs)"
 php artisan db:seed --class="Database\\Seeders\\LandlordDatabaseSeeder" --force
 
 echo "==> Tenants migrate (all tenants)"
-php artisan tenants:migrate:poc --force
+php artisan tenants:migrate:poc
 
 echo "==> Tenants seed (users, demo data, demo tokens)"
-php artisan tenants:seed:poc --force
+php artisan tenants:seed:poc
 
 start_laravel() {
   echo "==> Starting Laravel (http://127.0.0.1:8000) in background"


### PR DESCRIPTION
## Summary
- remove `--force` from tenant migrate and seed commands in bootstrap and Envoy scripts
- update README to match updated tenant commands

## Testing
- `php artisan migrate --database=landlord --path=database/migrations_landlord --force`
- `php artisan db:seed --class="Database\\Seeders\\LandlordDatabaseSeeder" --force`
- `php artisan tenants:migrate:poc` *(fails: Target class [Spatie\Multitenancy\Tasks\SwitchTenantCacheTask] does not exist)*
- `php artisan tenants:seed:poc` *(fails: Target class [Spatie\Multitenancy\Tasks\SwitchTenantCacheTask] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6896fbdfe25c832ebc06633210b1a4a5