### PR TITLE
Fix multitenancy cache task reference

### DIFF
--- a/backend/config/multitenancy.php
+++ b/backend/config/multitenancy.php
@@ -12,7 +12,7 @@ return [
 
     'switch_tenant_tasks' => [
         Spatie\Multitenancy\Tasks\SwitchTenantDatabaseTask::class,
-        Spatie\Multitenancy\Tasks\SwitchTenantCacheTask::class,
+        Spatie\Multitenancy\Tasks\PrefixCacheTask::class,
     ],
 
     'switch_tenant_tasks_queue' => [


### PR DESCRIPTION
## Summary
- Use `PrefixCacheTask` instead of removed `SwitchTenantCacheTask` in multitenancy config

## Testing
- `php artisan test` *(fails: Could not read XML from file "/workspace/erp-poc/backend/phpunit.xml.dist"*)

------
https://chatgpt.com/codex/tasks/task_e_6897005346b8832e89c152ad091894e4