### PR TITLE
Handle existing data in TenantSeeder

### DIFF
--- a/backend/database/seeders/TenantSeeder.php
+++ b/backend/database/seeders/TenantSeeder.php
@@ -10,6 +10,11 @@ class TenantSeeder extends Seeder
 {
     public function run(): void
     {
+        // Bail out if we've already seeded (admin user exists)
+        if (DB::connection('tenant')->table('users')->where('email', 'admin@example.test')->exists()) {
+            return;
+        }
+
         // USERS
         $adminId = DB::connection('tenant')->table('users')->insertGetId([
             'name' => 'Staff Admin',


### PR DESCRIPTION
## Summary
- Avoid duplicate user creation in TenantSeeder by skipping when the admin account already exists

## Testing
- `php artisan tenants:seed:poc` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `vendor/bin/phpunit` *(shows usage, no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_689702e5b5f0832e8eea6e8e9d4c1998