### PR TITLE
Include User model in morph map for token seeding

### DIFF
--- a/backend/app/Providers/TenancyServiceProvider.php
+++ b/backend/app/Providers/TenancyServiceProvider.php
@@ -50,6 +50,7 @@ class TenancyServiceProvider extends ServiceProvider
         // avoids touching the database and fixes bootstrapping.
         Relation::enforceMorphMap([
             'tenant' => \Spatie\Multitenancy\Models\Tenant::class,
+            'user' => \App\Models\User::class,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- add User model to Relation morph map so Sanctum tokens can be created during tenant seeding

## Testing
- `php artisan tenants:seed:poc` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `vendor/bin/phpunit` *(fails: PHPUnit 11.5.29, usage displayed; no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_689703c56540832e8937390f95d9b0d4