### PR TITLE
Add persistent storage directories to fix cache path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 backend/vendor/
 backend/node_modules/
 backend/.env
-backend/storage/
 backend/bootstrap/cache/
 backend/public/storage/
 

--- a/backend/storage/.gitignore
+++ b/backend/storage/.gitignore
@@ -1,0 +1,5 @@
+*
+!.gitignore
+!app/
+!framework/
+!logs/

--- a/backend/storage/app/.gitignore
+++ b/backend/storage/app/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/backend/storage/framework/.gitignore
+++ b/backend/storage/framework/.gitignore
@@ -1,0 +1,5 @@
+*
+!.gitignore
+!cache/
+!sessions/
+!views/

--- a/backend/storage/framework/cache/.gitignore
+++ b/backend/storage/framework/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/backend/storage/framework/sessions/.gitignore
+++ b/backend/storage/framework/sessions/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/backend/storage/framework/views/.gitignore
+++ b/backend/storage/framework/views/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/backend/storage/logs/.gitignore
+++ b/backend/storage/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- ensure Laravel storage directories exist with placeholder .gitignore files
- update root ignore rules so storage paths are tracked

## Testing
- `php artisan test` *(fails: Could not read XML from file "/workspace/erp-poc/backend/phpunit.xml.dist")*

------
https://chatgpt.com/codex/tasks/task_e_689709a9c8e0832ea9b2caa1d6452f92