### PR TITLE
Fix API route prefix causing 404 on token endpoint

### DIFF
--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -3,7 +3,10 @@
 use Illuminate\Support\Facades\Route;
 use Illuminate\Http\Request;
 
-Route::prefix('api/v1')->group(function () {
+// API routes are automatically prefixed with `/api` via Laravel's routing
+// configuration in `bootstrap/app.php`. We only need to prefix the version
+// segment here to avoid generating paths like `/api/api/v1`.
+Route::prefix('v1')->group(function () {
 
     // Health
     Route::get('health', fn () => response()->json(['status' => 'ok']))->name('health');


### PR DESCRIPTION
## Summary
- avoid double `/api` prefix that made `/api/v1` requests return 404

## Testing
- `php -l backend/routes/api.php`
- `php backend/artisan route:list` *(fails: Failed opening required '/workspace/erp-poc/backend/vendor/autoload.php')*
- `cd frontend && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68970b995834832e954e6696ea830da8