### PR TITLE
Ensure tenant DB used for user models

### DIFF
--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -2,14 +2,19 @@
 
 namespace App\Models;
 
-use Illuminate\Foundation\Auth\User as Authenticatable;
-use Laravel\Sanctum\HasApiTokens;
-use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
     use HasApiTokens, Notifiable;
+
+    /**
+     * Use the tenant database connection.
+     */
+    protected $connection = 'tenant';
 
     protected $guarded = [];
 
@@ -32,9 +37,12 @@ class User extends Authenticatable
         foreach ($this->roles as $role) {
             if ($role->module_key === $moduleKey) {
                 $have = $priority[$role->role] ?? 0;
-                if ($have >= $needed) return true;
+                if ($have >= $needed) {
+                    return true;
+                }
             }
         }
+
         return false;
     }
 }

--- a/backend/app/Models/UserRole.php
+++ b/backend/app/Models/UserRole.php
@@ -7,6 +7,11 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class UserRole extends Model
 {
+    /**
+     * Use the tenant database connection.
+     */
+    protected $connection = 'tenant';
+
     protected $guarded = [];
 
     public function user(): BelongsTo


### PR DESCRIPTION
## Summary
- use tenant database connection for User and UserRole models so authentication queries resolve tables within tenant DBs

## Testing
- `php -l backend/app/Models/User.php`
- `php -l backend/app/Models/UserRole.php`
- `./vendor/bin/pint app/Models/User.php app/Models/UserRole.php`
- `php artisan test` *(fails: Could not read XML from file "phpunit.xml.dist")*

------
https://chatgpt.com/codex/tasks/task_e_68970d23e5a8832eb22badd064ff0d84