### PR TITLE
Fix Sanctum guard and middleware registration

### DIFF
--- a/backend/app/Http/Kernel.php
+++ b/backend/app/Http/Kernel.php
@@ -2,10 +2,10 @@
 
 namespace App\Http;
 
-use Illuminate\Foundation\Http\Kernel as HttpKernel;
+use App\Http\Middleware\CheckModulePermission;
 use App\Http\Middleware\TenantFromHeader;
 use App\Http\Middleware\TenantTokenScope;
-use App\Http\Middleware\CheckModulePermission;
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
 
 class Kernel extends HttpKernel
 {
@@ -22,7 +22,7 @@ class Kernel extends HttpKernel
         ],
     ];
 
-    protected $routeMiddleware = [
+    protected $middlewareAliases = [
         'module.permission' => CheckModulePermission::class,
     ];
 }

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -7,6 +7,7 @@ return Application::configure(basePath: dirname(__DIR__))
         App\Providers\AppServiceProvider::class,
         App\Providers\AuthServiceProvider::class,
         App\Providers\EventServiceProvider::class,
+        Laravel\Sanctum\SanctumServiceProvider::class,
         Spatie\Multitenancy\MultitenancyServiceProvider::class,
         App\Providers\TenancyServiceProvider::class,
         App\Providers\ModulesServiceProvider::class,


### PR DESCRIPTION
## Summary
- register Sanctum service provider to enable `sanctum` auth guard
- register module permission middleware with new `$middlewareAliases` property

## Testing
- `./vendor/bin/pint app/Http/Kernel.php bootstrap/app.php`
- `php vendor/bin/phpunit` *(fails: configuration usage info, no tests)*

------
https://chatgpt.com/codex/tasks/task_e_68970f45b8d0832ebbdda59e4c51d638