### PR TITLE
Fix union index filter handling

### DIFF
--- a/backend/modules/Membership/Http/Controllers/Api/V1/UnionController.php
+++ b/backend/modules/Membership/Http/Controllers/Api/V1/UnionController.php
@@ -2,17 +2,18 @@
 
 namespace Modules\Membership\Http\Controllers\Api\V1;
 
-use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
-use Modules\Membership\Models\Union;
+use Illuminate\Routing\Controller;
 use Modules\Membership\Http\Resources\UnionResource;
+use Modules\Membership\Models\Union;
 
 class UnionController extends Controller
 {
     public function index(Request $request)
     {
-        $q = Union::query()->when($request->filled('filter[name]'), fn($qq) =>
-            $qq->where('name', 'like', '%'.$request->input('filter.name').'%')
+        $q = Union::query()->when(
+            $request->filled('filter.name'),
+            fn ($qq) => $qq->where('name', 'like', '%'.$request->input('filter.name').'%')
         );
 
         return UnionResource::collection($q->paginate(10));
@@ -21,11 +22,12 @@ class UnionController extends Controller
     public function store(Request $request)
     {
         $data = $request->validate([
-            'name'=>'required|string',
-            'code'=>'required|string|unique:unions,code',
+            'name' => 'required|string',
+            'code' => 'required|string|unique:unions,code',
         ]);
 
         $union = Union::create($data);
+
         return (new UnionResource($union))->response()->setStatusCode(201);
     }
 
@@ -37,16 +39,18 @@ class UnionController extends Controller
     public function update(Request $request, Union $union)
     {
         $data = $request->validate([
-            'name'=>'sometimes|string',
-            'code'=>'sometimes|string|unique:unions,code,'.$union->id,
+            'name' => 'sometimes|string',
+            'code' => 'sometimes|string|unique:unions,code,'.$union->id,
         ]);
         $union->update($data);
+
         return new UnionResource($union);
     }
 
     public function destroy(Union $union)
     {
         $union->delete();
+
         return response()->json(null, 204);
     }
 }


### PR DESCRIPTION
## Summary
- ensure union index uses dot notation for `filter.name`

## Testing
- `./vendor/bin/pint modules/Membership/Http/Controllers/Api/V1/UnionController.php`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689711aeb3a8832e98794e7c67f2368e