### PR TITLE
Fix Sanctum tokens and module permission middleware

### DIFF
--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -1,6 +1,12 @@
 <?php
 
+use App\Http\Middleware\CheckModulePermission;
+use App\Http\Middleware\TenantFromHeader;
+use App\Http\Middleware\TenantTokenScope;
+use Fruitcake\Cors\HandleCors;
 use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withProviders([
@@ -18,8 +24,17 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         health: '/up'
     )
-    ->withMiddleware(function ($middleware) {
-        //
+    ->withMiddleware(function (Middleware $middleware) {
+        $middleware->append([HandlePrecognitiveRequests::class, HandleCors::class]);
+
+        $middleware->api(prepend: [
+            TenantFromHeader::class,
+            TenantTokenScope::class,
+        ]);
+
+        $middleware->alias([
+            'module.permission' => CheckModulePermission::class,
+        ]);
     })
     ->withExceptions(function ($exceptions) {
         //

--- a/backend/database/migrations_landlord/2025_08_08_010000_create_personal_access_tokens_table.php
+++ b/backend/database/migrations_landlord/2025_08_08_010000_create_personal_access_tokens_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};


### PR DESCRIPTION
## Summary
- add landlord personal_access_tokens migration for Sanctum
- register module.permission middleware and tenancy APIs in application bootstrap

## Testing
- `composer install`
- `php artisan test` *(fails: Could not read XML from file "/workspace/erp-poc/backend/phpunit.xml.dist")*

------
https://chatgpt.com/codex/tasks/task_e_6897166d1fa8832e9082d74b6f87ca61