### PR TITLE
fix: use built-in CORS middleware

### DIFF
--- a/backend/app/Http/Kernel.php
+++ b/backend/app/Http/Kernel.php
@@ -11,7 +11,7 @@ class Kernel extends HttpKernel
 {
     protected $middleware = [
         \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
-        \Fruitcake\Cors\HandleCors::class,
+        \Illuminate\Http\Middleware\HandleCors::class,
     ];
 
     protected $middlewareGroups = [

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -3,10 +3,10 @@
 use App\Http\Middleware\CheckModulePermission;
 use App\Http\Middleware\TenantFromHeader;
 use App\Http\Middleware\TenantTokenScope;
-use Fruitcake\Cors\HandleCors;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests;
+use Illuminate\Http\Middleware\HandleCors;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withProviders([


### PR DESCRIPTION
## Summary
- use Laravel's built-in `HandleCors` middleware instead of Fruitcake implementation

## Testing
- `./vendor/bin/phpunit` *(fails: shows usage, no tests configured)*
- `./vendor/bin/pint app/Http/Kernel.php bootstrap/app.php`


------
https://chatgpt.com/codex/tasks/task_e_689719b24ed0832e974834136e56e132