### PR TITLE
refactor: centralize middleware setup and reset tenant on logout

### DIFF
--- a/backend/app/Http/Kernel.php
+++ b/backend/app/Http/Kernel.php
@@ -2,27 +2,9 @@
 
 namespace App\Http;
 
-use App\Http\Middleware\CheckModulePermission;
-use App\Http\Middleware\TenantFromHeader;
-use App\Http\Middleware\TenantTokenScope;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 
 class Kernel extends HttpKernel
 {
-    protected $middleware = [
-        \Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests::class,
-        \Illuminate\Http\Middleware\HandleCors::class,
-    ];
-
-    protected $middlewareGroups = [
-        'api' => [
-            \Illuminate\Routing\Middleware\SubstituteBindings::class,
-            TenantFromHeader::class,    // ensures TenantFinder sees header
-            TenantTokenScope::class,    // ensures token matches tenant
-        ],
-    ];
-
-    protected $middlewareAliases = [
-        'module.permission' => CheckModulePermission::class,
-    ];
+    // Middleware is configured in bootstrap/app.php
 }

--- a/frontend/src/store/auth.js
+++ b/frontend/src/store/auth.js
@@ -5,7 +5,10 @@ const DEVICE = 'web-spa'
 export const auth = {
   get token() { return localStorage.getItem(TOKEN_KEY) || '' },
   set token(v) { localStorage.setItem(TOKEN_KEY, v || '') },
-  clear() { localStorage.removeItem(TOKEN_KEY) },
+  clear() {
+    localStorage.removeItem(TOKEN_KEY)
+    localStorage.removeItem(TENANT_KEY)
+  },
   isAuthenticated() { return !!localStorage.getItem(TOKEN_KEY) },
 
   get tenant() { return localStorage.getItem(TENANT_KEY) || '' },


### PR DESCRIPTION
## Summary
- remove duplicate middleware configuration from Http\Kernel and rely on bootstrap setup
- clear tenant selection along with token during logout

## Testing
- `npm run build`
- `composer validate`
- `./vendor/bin/pint --test app/Http/Kernel.php`


------
https://chatgpt.com/codex/tasks/task_e_68971dee0198832e8701ac49e1274bfe