### PR TITLE
Allow unauthenticated requests in tenant token scope

### DIFF
--- a/backend/app/Http/Middleware/TenantTokenScope.php
+++ b/backend/app/Http/Middleware/TenantTokenScope.php
@@ -13,7 +13,10 @@ class TenantTokenScope
         $currentTenantId = Tenant::current()?->id;
         $tokenTenantId = auth()->user()?->currentAccessToken()?->tenant_id;
 
-        if ($currentTenantId !== $tokenTenantId) {
+        // Only enforce tenant scope when a token is present. This allows
+        // unauthenticated requests (e.g. requesting a token) to pass through
+        // without triggering a mismatch error.
+        if ($tokenTenantId !== null && $currentTenantId !== $tokenTenantId) {
             return response()->json([
                 'error' => [
                     'status' => 403,


### PR DESCRIPTION
## Summary
- Prevent TenantTokenScope middleware from blocking unauthenticated requests

## Testing
- `composer install`
- `php artisan test` *(fails: Could not read XML from file "/workspace/erp-poc/backend/phpunit.xml.dist")*


------
https://chatgpt.com/codex/tasks/task_e_68971fbe2ee4832e9cbe9e0fe82e0bd3